### PR TITLE
[SST-126] Create installable Python3 module for google_auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Project specific files
+client_secret.json
+client_credentials.json
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+"oauth2client" = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.7"

--- a/Pipfile
+++ b/Pipfile
@@ -9,4 +9,4 @@ name = "pypi"
 [dev-packages]
 
 [requires]
-python_version = "3.7"
+python_version = "3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "63e1cb925277c1ee3c3be562b99b5eb1446b30e19e3087e8d65234a27e14e369"
+            "sha256": "d351cbcf1c17089b8cb1abd9a8b9ff822f81e29052407549fa7a4071bba8ac93"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3"
         },
         "sources": [
             {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,63 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "63e1cb925277c1ee3c3be562b99b5eb1446b30e19e3087e8d65234a27e14e369"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "httplib2": {
+            "hashes": [
+                "sha256:e71daed9a0e6373642db61166fa70beecc9bf04383477f84671348c02a04cbdf"
+            ],
+            "version": "==0.11.3"
+        },
+        "oauth2client": {
+            "hashes": [
+                "sha256:bd3062c06f8b10c6ef7a890b22c2740e5f87d61b6e1f4b1c90d069cdfc9dadb5",
+                "sha256:cf061f52f75e91d489bf5c276498f8af2655fe331b454f10022441513cf445a6"
+            ],
+            "index": "pypi",
+            "version": "==4.1.2"
+        },
+        "pyasn1": {
+            "hashes": [
+                "sha256:b9d3abc5031e61927c82d4d96c1cec1e55676c1a991623cfed28faea73cdd7ca",
+                "sha256:f58f2a3d12fd754aa123e9fa74fb7345333000a035f3921dbdaa08597aa53137"
+            ],
+            "version": "==0.4.4"
+        },
+        "pyasn1-modules": {
+            "hashes": [
+                "sha256:a0cf3e1842e7c60fde97cb22d275eb6f9524f5c5250489e292529de841417547",
+                "sha256:a38a8811ea784c0136abfdba73963876328f66172db21a05a82f9515909bfb4e"
+            ],
+            "version": "==0.2.2"
+        },
+        "rsa": {
+            "hashes": [
+                "sha256:25df4e10c263fb88b5ace923dd84bf9aa7f5019687b5e55382ffcdb8bede9db5",
+                "sha256:43f682fea81c452c98d09fc316aae12de6d30c4b5c84226642cf8f8fd1c93abd"
+            ],
+            "version": "==3.4.2"
+        },
+        "six": {
+            "hashes": [
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+            ],
+            "version": "==1.11.0"
+        }
+    },
+    "develop": {}
+}

--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ new credentials ( stored locally as `client_credentials.json` ).
 - Scopes are space separated
 - If modifying the module's scopes, delete the previously saved credentials at `client_credentials.json`
 
+This module has default Scopes defined.
+HOWEVER -- scopes can be passed into `get_credentials()` as a named argument
+for users who wish to specify different Scopes:
+
+```python
+myScopes=' '.join(list(
+    ('foo', 'bar')
+))
+credentials = get_credentials('myUniqueAppName', scopes=myScopes)
+```
+
 ## The WHYs
 
 ### Why was this module developed ?

--- a/README.md
+++ b/README.md
@@ -48,10 +48,7 @@ HOWEVER -- scopes can be passed into `get_credentials()` as a named argument
 for users who wish to specify different Scopes:
 
 ```python
-myScopes=' '.join(list(
-    ('foo', 'bar')
-))
-credentials = get_credentials('myUniqueAppName', scopes=myScopes)
+credentials = get_credentials('myUniqueAppName', scopes=('foo', 'bar'))
 ```
 
 ## The WHYs

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ new credentials ( stored locally as `client_credentials.json` ).
 - Scopes are space separated
 - If modifying the module's scopes, delete the previously saved credentials at `client_credentials.json`
 
-## Why was this module developed?
+## The WHYs
+
+### Why was this module developed ?
 
 Authenticating ( and subsequently using ) Google services
 can be somewhat arcane, at least from within Python
@@ -51,6 +53,14 @@ applications.
 
 This module was developed to make authentication as
 simple as possible.
+
+### Why use OAuth2?
+( AKA, "Why not use simple token authentication?" )
+
+Using Google API keys are only usable for accessing _public_ resources in Google.
+Accessing _private_ resources ( Sheets, Docs, etc. ) requires OAuth2.
+
+**Important Note**: Authenticating via OAuth2 from scratch requires manual intervention the first time.
 
 ### Reference
 https://developers.google.com/sheets/api/quickstart/python

--- a/google_auth/__init__.py
+++ b/google_auth/__init__.py
@@ -1,0 +1,3 @@
+from .google_auth import get_credentials
+
+__all__ = ['get_credentials']

--- a/google_auth/google_auth.py
+++ b/google_auth/google_auth.py
@@ -1,0 +1,45 @@
+from __future__ import print_function
+import argparse
+import os
+
+from oauth2client import client
+from oauth2client import tools
+from oauth2client.file import Storage
+
+
+# https://developers.google.com/sheets/api/quickstart/python
+
+# SCOPES are defined at https://developers.google.com/identity/protocols/googlescopes
+# SCOPES are space separated
+# If modifying these scopes, delete your previously saved credentials
+# at CLIENT_CREDENTIALS_FILE
+_SCOPES = ('https://www.googleapis.com/auth/spreadsheets', 'https://www.googleapis.com/auth/drive.file')
+CLIENT_SECRET_FILE = 'client_secret.json'
+CLIENT_CREDENTIALS_FILE = 'client_credentials.json'
+
+
+def get_credentials(app_name, scopes=_SCOPES):
+    """Gets valid user credentials from storage.
+
+    If nothing has been stored, or if the stored credentials are invalid,
+    the OAuth2 flow is completed to obtain the new credentials.
+
+    Returns:
+        Credentials, the obtained credential.
+    """
+    scopes = ' '.join(list(scopes))
+    clientfile = os.path.join(os.path.expanduser('.'), CLIENT_SECRET_FILE)
+    credfile = os.path.join(os.path.expanduser('.'), CLIENT_CREDENTIALS_FILE)
+
+    store = Storage(credfile)
+    credentials = store.get()
+    if not credentials or credentials.invalid:
+        flow = client.flow_from_clientsecrets(clientfile, scopes)
+        flow.user_agent = app_name
+        flags = argparse.ArgumentParser(parents=[tools.argparser]).parse_args(args=[])
+        if flags:
+            credentials = tools.run_flow(flow, store, flags)
+        else: # Needed only for compatibility with Python 2.6
+            credentials = tools.run(flow, store)
+        print('Storing credentials to ' + credfile)
+    return credentials

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,70 @@
+"""A setuptools based setup module.
+
+See:
+https://packaging.python.org/en/latest/distributing.html
+https://github.com/pypa/sampleproject
+"""
+
+# Always prefer setuptools over distutils
+from setuptools import setup, find_packages
+from os import path
+# io.open is needed for projects that support Python 2.7
+# It ensures open() defaults to text mode with universal newlines,
+# and accepts an argument to specify the text encoding
+# Python 3 only projects can skip this import
+from io import open
+
+here = path.abspath(path.dirname(__file__))
+
+# Get the long description from the README file
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+# Arguments marked as "Required" below must be included for upload to PyPI.
+# Fields marked as "Optional" may be commented out.
+
+setup(
+    # This is the name of your project. The first time you publish this
+    # package, this name will be registered for you. It will determine how
+    # users can install this project, e.g.:
+    #
+    # $ pip install sampleproject
+    #
+    # And where it will live on PyPI: https://pypi.org/project/sampleproject/
+    #
+    # There are some restrictions on what makes a valid project name
+    # specification here:
+    # https://packaging.python.org/specifications/core-metadata/#name
+    name='google_auth',  # Required
+
+    # Versions should comply with PEP 440:
+    # https://www.python.org/dev/peps/pep-0440/
+    #
+    # For a discussion on single-sourcing the version across setup.py and the
+    # project code, see
+    # https://packaging.python.org/en/latest/single_source_version.html
+    version='1.0.0',  # Required
+
+    description='A Python3 library for handling Google authentication for services such as Google Drive and Google Docs',  # Required
+
+    long_description=long_description,  # Optional
+
+    long_description_content_type='text/markdown',  # Optional (see note above)
+
+    url='https://github.com/rewardStyle/google_auth',  # Optional
+
+    author='rewardStyle DevOps',  # Optional
+
+    author_email='devops@rewardstyle.com',  # Optional
+
+    packages=find_packages(exclude=['Pipfile', 'Pipfile.lock', 'client_secret.json', 'client_credentials.json']),  # Required
+
+    install_requires=['oauth2client'],  # Optional
+
+    project_urls={  # Optional
+        'Bug Reports': 'https://github.com/rewardStyle/google_auth/issues',
+        'Source': 'https://github.com/rewardStyle/google_auth',
+        'Google API Docs': 'https://developers.google.com/sheets/api/quickstart/python',
+        'Google Auth Scopes Docs': 'https://developers.google.com/identity/protocols/googlescopes'
+    },
+)


### PR DESCRIPTION
This PR actually defines the google_auth module.

Tested locally and appears to be working fine:

```bash
[brianshef@BShefs-MacBook-Pro /nastygoat/google_auth]$ pipenv shell
Launching subshell in virtual environment…
 . /nastygoat/google_auth/.venv/bin/activate
[brianshef@BShefs-MacBook-Pro /nastygoat/google_auth]$  . /nastygoat/google_auth/.venv/bin/activate
(google_auth)[brianshef@BShefs-MacBook-Pro /nastygoat/google_auth]$ pip install -e git+git://github.com/rewardStyle/google_auth.git@sst-126#egg=google_auth
The directory '/Users/brianshef/Library/Caches/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
The directory '/Users/brianshef/Library/Caches/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
Obtaining google_auth from git+git://github.com/rewardStyle/google_auth.git@sst-126#egg=google_auth
  Updating ./.venv/src/google-auth clone (to revision sst-126)
Requirement already satisfied: oauth2client in ./.venv/lib/python3.6/site-packages (from google_auth) (4.1.2)
Requirement already satisfied: pyasn1-modules>=0.0.5 in ./.venv/lib/python3.6/site-packages (from oauth2client->google_auth) (0.2.2)
Requirement already satisfied: six>=1.6.1 in ./.venv/lib/python3.6/site-packages (from oauth2client->google_auth) (1.11.0)
Requirement already satisfied: pyasn1>=0.1.7 in ./.venv/lib/python3.6/site-packages (from oauth2client->google_auth) (0.4.4)
Requirement already satisfied: httplib2>=0.9.1 in ./.venv/lib/python3.6/site-packages (from oauth2client->google_auth) (0.11.3)
Requirement already satisfied: rsa>=3.1.4 in ./.venv/lib/python3.6/site-packages (from oauth2client->google_auth) (3.4.2)
google-api-python-client 1.7.4 has requirement google-auth>=1.4.1, but you'll have google-auth 1.0.0 which is incompatible.
Installing collected packages: google-auth
  Found existing installation: google-auth 1.0.0
    Uninstalling google-auth-1.0.0:
      Successfully uninstalled google-auth-1.0.0
  Running setup.py develop for google-auth
Successfully installed google-auth
(google_auth)[brianshef@BShefs-MacBook-Pro /nastygoat/google_auth]$ python3
Python 3.6.3 (v3.6.3:2c5fed86e0, Oct  3 2017, 00:32:08)
[GCC 4.2.1 (Apple Inc. build 5666) (dot 3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import google_auth
>>> print(google_auth.get_credentials)
<function get_credentials at 0x10187e1e0>
```